### PR TITLE
OY-3070 add synthetic application flag and form key to haku

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@
 /target/
 /projectFilesBackup/
 .lsp/
+.clj-kondo/

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PM2 = PM2_HOME=.pm2 npx pm2
 DOCKER_COMPOSE=COMPOSE_PARALLEL_LIMIT=8 $(if $(DOCKER_SUDO),sudo )docker-compose
 
 $(NODE_MODULES): package.json package-lock.json
-	npm install
+	npm ci
 	touch $(NODE_MODULES)
 
 start-docker:

--- a/oph-configuration/config.cypress.local-environment.edn
+++ b/oph-configuration/config.cypress.local-environment.edn
@@ -23,4 +23,5 @@
  :oph-organisaatio-oid "1.2.246.562.10.00000000001"
  :public-config        {:environment   :it
                         :default-panel :panel/hakukohderyhmien-hallinta
-                        :caller-id     "1.2.246.562.10.00000000001.hakukohderyhmapalvelu.frontend"}}
+                        :caller-id     "1.2.246.562.10.00000000001.hakukohderyhmapalvelu.frontend"
+                        :synthetic-application-form-key "c1748e22-548a-4b1f-9ddf-f0c3d0ee820a"}}

--- a/oph-configuration/config.cypress.travis.edn
+++ b/oph-configuration/config.cypress.travis.edn
@@ -23,4 +23,5 @@
  :oph-organisaatio-oid "1.2.246.562.10.00000000001"
  :public-config        {:environment   :it
                         :default-panel :panel/hakukohderyhmien-hallinta
-                        :caller-id     "1.2.246.562.10.00000000001.hakukohderyhmapalvelu.frontend"}}
+                        :caller-id     "1.2.246.562.10.00000000001.hakukohderyhmapalvelu.frontend"
+                        :synthetic-application-form-key "c1748e22-548a-4b1f-9ddf-f0c3d0ee820a"}}

--- a/oph-configuration/config.edn.template
+++ b/oph-configuration/config.edn.template
@@ -23,4 +23,5 @@
  :oph-organisaatio-oid "1.2.246.562.10.00000000001"
  :public-config        {:environment   {{ hakukohderyhmapalvelu_environment | default(':development') }}
                         :default-panel :panel/hakukohderyhmien-hallinta
-                        :caller-id     "{{hakukohderyhmapalvelu_frontend_caller_id | default('1.2.246.562.10.00000000001.hakukohderyhmapalvelu.frontend')}}"}}
+                        :caller-id     "{{hakukohderyhmapalvelu_frontend_caller_id | default('1.2.246.562.10.00000000001.hakukohderyhmapalvelu.frontend')}}"
+                        :synthetic-application-form-key "c1748e22-548a-4b1f-9ddf-f0c3d0ee820a"}}

--- a/oph-configuration/config.edn.template
+++ b/oph-configuration/config.edn.template
@@ -24,4 +24,4 @@
  :public-config        {:environment   {{ hakukohderyhmapalvelu_environment | default(':development') }}
                         :default-panel :panel/hakukohderyhmien-hallinta
                         :caller-id     "{{hakukohderyhmapalvelu_frontend_caller_id | default('1.2.246.562.10.00000000001.hakukohderyhmapalvelu.frontend')}}"
-                        :synthetic-application-form-key "c1748e22-548a-4b1f-9ddf-f0c3d0ee820a"}}
+                        :synthetic-application-form-key "{{ hakukohderyhmapalvelu_synthetic_application_form_key | default('c1748e22-548a-4b1f-9ddf-f0c3d0ee820a') }}"}}

--- a/resources/hakukohderyhmapalvelu-oph.properties
+++ b/resources/hakukohderyhmapalvelu-oph.properties
@@ -10,6 +10,7 @@ cas.failure = ${url-hakukohderyhmapalvelu}/login-error
 
 cas.service.kayttooikeus-service=${virkailija.baseurl}/kayttooikeus-service/j_spring_cas_security_check
 kayttooikeus-service.kayttooikeus.kayttaja = ${virkailija.baseurl}/kayttooikeus-service/kayttooikeus/kayttaja
+front.kayttooikeus-service.me = ${virkailija.baseurl}/kayttooikeus-service/cas/me
 
 cas.service.organisaatio-service=https://${host.virkailija}/organisaatio-service/j_spring_cas_security_check
 organisaatio-service.baseurl=${virkailija.baseurl}

--- a/src/cljc/hakukohderyhmapalvelu/public_config_schemas.cljc
+++ b/src/cljc/hakukohderyhmapalvelu/public_config_schemas.cljc
@@ -3,10 +3,11 @@
 
 (s/defschema PublicConfig
   {:environment   (s/enum
-                    :production
-                    :development
-                    :it)
+                   :production
+                   :development
+                   :it)
    :default-panel (s/enum
-                    :panel/hakukohderyhmien-hallinta
-                    :panel/haun-asetukset)
-   :caller-id     s/Str})
+                   :panel/hakukohderyhmien-hallinta
+                   :panel/haun-asetukset)
+   :caller-id     s/Str
+   :synthetic-application-form-key s/Str})

--- a/src/cljs/hakukohderyhmapalvelu/events/haun_asetukset_events.cljs
+++ b/src/cljs/hakukohderyhmapalvelu/events/haun_asetukset_events.cljs
@@ -44,6 +44,7 @@
                  response
                  [:nimi
                   :hakulomakeAtaruId
+                  :hakulomaketyyppi
                   :kohdejoukkoKoodiUri
                   :hakuajat])]
       (assoc-in db

--- a/src/cljs/hakukohderyhmapalvelu/events/haun_asetukset_events.cljs
+++ b/src/cljs/hakukohderyhmapalvelu/events/haun_asetukset_events.cljs
@@ -3,7 +3,25 @@
             [hakukohderyhmapalvelu.macros.event-macros :as events]
             [hakukohderyhmapalvelu.urls :as urls]
             [day8.re-frame.tracing :refer-macros [fn-traced]]
-            [hakukohderyhmapalvelu.i18n.utils :as i18n-utils]))
+            [hakukohderyhmapalvelu.i18n.utils :as i18n-utils]
+            [clojure.string :as str]))
+
+(events/reg-event-fx-validating
+ :haun-asetukset/get-user-rights
+ (fn-traced [_ _]
+            (let [url (urls/get-url :kayttooikeus-service.me)]
+              {:http {:http-request-id  :haun-asetukset/get-user-rights
+                      :method           :get
+                      :path             url
+                      :response-handler [:haun-asetukset/handle-get-user-rights]
+                      :body             {}}})))
+
+(events/reg-event-db-validating
+ :haun-asetukset/handle-get-user-rights
+ (fn-traced [db [response]]
+            (->> (:groups response)
+                 (filter (fn [right] (str/starts-with? right "APP_HAKUKOHDERYHMAPALVELU")))
+                 (assoc db :user-groups))))
 
 (events/reg-event-fx-validating
   :haun-asetukset/get-forms

--- a/src/cljs/hakukohderyhmapalvelu/events/panel_events.cljs
+++ b/src/cljs/hakukohderyhmapalvelu/events/panel_events.cljs
@@ -8,6 +8,7 @@
 (defn- make-haun-asetukset-dispatches [{:keys [query]}]
   (let [haku-oid (:haku-oid query)]
     [[:haun-asetukset/get-forms]
+     [:haun-asetukset/get-user-rights]
      [:haun-asetukset/get-haku haku-oid]
      [:haun-asetukset/get-ohjausparametrit haku-oid]]))
 

--- a/src/cljs/hakukohderyhmapalvelu/i18n/translations.cljs
+++ b/src/cljs/hakukohderyhmapalvelu/i18n/translations.cljs
@@ -17,6 +17,7 @@
                     :useita-hakemuksia                                           {:fi "Vain yksi hakemus -rajoitus"}
                     :haun-asetukset                                              {:fi "Haun asetukset"}
                     :synteettiset-hakemukset                                     {:fi "Haussa käytetään synteettisiä hakemuksia"}
+                    :synteettisen-hakemuksen-lomakeavain                         {:fi "Synteettisten hakemusten lomakeavain"}
                     :hakukohteiden-enimmaismaara                                 {:fi "Hakutoiveiden enimmäismäärä"}
                     :hakukierros-paattyy                                         {:fi "Hakukierros päättyy"}
                     :varasijataytto-paattyy                                      {:fi "Varasijatäyttö päättyy"}

--- a/src/cljs/hakukohderyhmapalvelu/i18n/translations.cljs
+++ b/src/cljs/hakukohderyhmapalvelu/i18n/translations.cljs
@@ -16,6 +16,7 @@
    :haun-asetukset {:valintatulokset-valmiina-viimeistaan                        {:fi "Valintatulokset valmiina viimeistään"}
                     :useita-hakemuksia                                           {:fi "Vain yksi hakemus -rajoitus"}
                     :haun-asetukset                                              {:fi "Haun asetukset"}
+                    :synteettiset-hakemukset                                     {:fi "Haussa käytetään synteettisiä hakemuksia"}
                     :hakukohteiden-enimmaismaara                                 {:fi "Hakutoiveiden enimmäismäärä"}
                     :hakukierros-paattyy                                         {:fi "Hakukierros päättyy"}
                     :varasijataytto-paattyy                                      {:fi "Varasijatäyttö päättyy"}

--- a/src/cljs/hakukohderyhmapalvelu/ohjausparametrit/haun_asetukset_ohjausparametrit_mapping.cljs
+++ b/src/cljs/hakukohderyhmapalvelu/ohjausparametrit/haun_asetukset_ohjausparametrit_mapping.cljs
@@ -15,6 +15,9 @@
     :haun-asetukset/synteettiset-hakemukset
     :synteettisetHakemukset
 
+    :haun-asetukset/synteettisen-hakemuksen-lomakeavain
+    :synteettisetLomakeavain
+
     :haun-asetukset/useita-hakemuksia
     :useitaHakemuksia
 

--- a/src/cljs/hakukohderyhmapalvelu/ohjausparametrit/haun_asetukset_ohjausparametrit_mapping.cljs
+++ b/src/cljs/hakukohderyhmapalvelu/ohjausparametrit/haun_asetukset_ohjausparametrit_mapping.cljs
@@ -12,6 +12,9 @@
     :haun-asetukset/jarjestetyt-hakutoiveet
     :jarjestetytHakutoiveet
 
+    :haun-asetukset/synteettiset-hakemukset
+    :synteettisetHakemukset
+
     :haun-asetukset/useita-hakemuksia
     :useitaHakemuksia
 
@@ -69,6 +72,7 @@
   (some #{haun-asetus-key}
         #{:haun-asetukset/hakukohteiden-maara-rajoitettu
           :haun-asetukset/jarjestetyt-hakutoiveet
+          :haun-asetukset/synteettiset-hakemukset
           :haun-asetukset/useita-hakemuksia
           :haun-asetukset/sijoittelu}))
 

--- a/src/cljs/hakukohderyhmapalvelu/schemas/app_db_schemas.cljs
+++ b/src/cljs/hakukohderyhmapalvelu/schemas/app_db_schemas.cljs
@@ -145,6 +145,7 @@
    (s/optional-key :hakutoiveidenEnimmaismaara)   s/Int
    (s/optional-key :useitaHakemuksia)             s/Bool
    (s/optional-key :sijoittelu)                   s/Bool
+   (s/optional-key :synteettisetHakemukset)       s/Bool
    (s/optional-key :__modified__)                 s/Int
    (s/optional-key :__modifiedBy__)               s/Str
    s/Any s/Any})

--- a/src/cljs/hakukohderyhmapalvelu/schemas/app_db_schemas.cljs
+++ b/src/cljs/hakukohderyhmapalvelu/schemas/app_db_schemas.cljs
@@ -122,8 +122,8 @@
   {:changes-saved s/Bool
    :errors [s/Any]})
 
-(s/defschema UserRights
-  {(s/optional-key :user-rights) [s/Str]})
+(s/defschema UserGroups
+  {(s/optional-key :user-groups) [s/Str]})
 
 (s/defschema HaunOhjausparametrit
   {(s/optional-key :PH_OPVP)                      (s/named
@@ -170,4 +170,4 @@
             Haut
             Forms
             HakujenOhjausparametrit
-            UserRights))
+            UserGroups))

--- a/src/cljs/hakukohderyhmapalvelu/schemas/app_db_schemas.cljs
+++ b/src/cljs/hakukohderyhmapalvelu/schemas/app_db_schemas.cljs
@@ -146,6 +146,7 @@
    (s/optional-key :useitaHakemuksia)             s/Bool
    (s/optional-key :sijoittelu)                   s/Bool
    (s/optional-key :synteettisetHakemukset)       s/Bool
+   (s/optional-key :synteettisetLomakeavain)      s/Str
    (s/optional-key :__modified__)                 s/Int
    (s/optional-key :__modifiedBy__)               s/Str
    s/Any s/Any})

--- a/src/cljs/hakukohderyhmapalvelu/schemas/app_db_schemas.cljs
+++ b/src/cljs/hakukohderyhmapalvelu/schemas/app_db_schemas.cljs
@@ -97,6 +97,7 @@
 
 (s/defschema HaunAsetukset
   {:nimi                               LocalizedString
+   (s/optional-key :hakulomaketyyppi)  s/Str
    (s/optional-key :hakulomakeAtaruId) s/Str
    :kohdejoukkoKoodiUri                KoodiUri
    :hakuajat                           [Hakuaika]})

--- a/src/cljs/hakukohderyhmapalvelu/schemas/app_db_schemas.cljs
+++ b/src/cljs/hakukohderyhmapalvelu/schemas/app_db_schemas.cljs
@@ -123,7 +123,7 @@
    :errors [s/Any]})
 
 (s/defschema UserRights
-  {:user-rights [s/Str]})
+  {(s/optional-key :user-rights) [s/Str]})
 
 (s/defschema HaunOhjausparametrit
   {(s/optional-key :PH_OPVP)                      (s/named

--- a/src/cljs/hakukohderyhmapalvelu/schemas/app_db_schemas.cljs
+++ b/src/cljs/hakukohderyhmapalvelu/schemas/app_db_schemas.cljs
@@ -122,6 +122,9 @@
   {:changes-saved s/Bool
    :errors [s/Any]})
 
+(s/defschema UserRights
+  {:user-rights [s/Str]})
+
 (s/defschema HaunOhjausparametrit
   {(s/optional-key :PH_OPVP)                      (s/named
                                                     OhjausparametritDate
@@ -166,4 +169,5 @@
             HakukohderyhmaPalvelu
             Haut
             Forms
-            HakujenOhjausparametrit))
+            HakujenOhjausparametrit
+            UserRights))

--- a/src/cljs/hakukohderyhmapalvelu/subs/haun_asetukset_subs.cljs
+++ b/src/cljs/hakukohderyhmapalvelu/subs/haun_asetukset_subs.cljs
@@ -113,6 +113,7 @@
   (fn [[_ haku-oid]]
     [(re-frame/subscribe [:haun-asetukset/haku haku-oid])])
   (fn [[haku]]
-    (some
-     ongoing-period?
-     (:hakuajat haku))))
+    (boolean
+     (some
+      ongoing-period?
+      (:hakuajat haku)))))

--- a/src/cljs/hakukohderyhmapalvelu/subs/haun_asetukset_subs.cljs
+++ b/src/cljs/hakukohderyhmapalvelu/subs/haun_asetukset_subs.cljs
@@ -113,7 +113,6 @@
   (fn [[_ haku-oid]]
     [(re-frame/subscribe [:haun-asetukset/haku haku-oid])])
   (fn [[haku]]
-    (boolean
-     (some
-      ongoing-period?
-      (:hakuajat haku)))))
+    (or
+     (not (contains? #{"ei sähköistä" "muu"} (:hakulomaketyyppi haku)))
+     (boolean (some ongoing-period? (:hakuajat haku))))))

--- a/src/cljs/hakukohderyhmapalvelu/views/haun_asetukset_panel.cljs
+++ b/src/cljs/hakukohderyhmapalvelu/views/haun_asetukset_panel.cljs
@@ -456,18 +456,20 @@
                                   {:value value}))]}]]))
 
 (defn- synteettiset-hakemukset [{:keys [haku-oid]}]
-  [haun-asetukset-checkbox
-   {:haku-oid                haku-oid
-    :haun-asetus-key         :haun-asetukset/synteettiset-hakemukset
-    :type                    :slider
-    :on-change               (fn [checked?]
-                               (re-frame/dispatch [:haun-asetukset/set-haun-asetus
-                                                   haku-oid
-                                                   :haun-asetukset/synteettisen-hakemuksen-lomakeavain
-                                                   (if checked?
-                                                     default-synthetic-application-form-key
-                                                     nil)]))
-    :bold-left-label-margin? false}])
+  (let [disabled? @(re-frame/subscribe [:haun-asetukset/synteettiset-hakemukset-disabled? haku-oid])]
+    [haun-asetukset-checkbox
+     {:haku-oid                haku-oid
+      :haun-asetus-key         :haun-asetukset/synteettiset-hakemukset
+      :type                    :slider
+      :disabled?               disabled?
+      :on-change               (fn [checked?]
+                                 (re-frame/dispatch [:haun-asetukset/set-haun-asetus
+                                                     haku-oid
+                                                     :haun-asetukset/synteettisen-hakemuksen-lomakeavain
+                                                     (if checked?
+                                                       default-synthetic-application-form-key
+                                                       nil)]))
+      :bold-left-label-margin? false}]))
 
 (defn- haun-asetukset-sijoittelu [{:keys [haku-oid]}]
   (let [sijoittelu? @(re-frame/subscribe [:haun-asetukset/haun-asetus haku-oid :haun-asetukset/sijoittelu])]

--- a/src/cljs/hakukohderyhmapalvelu/views/haun_asetukset_panel.cljs
+++ b/src/cljs/hakukohderyhmapalvelu/views/haun_asetukset_panel.cljs
@@ -122,6 +122,7 @@
                                         haun-asetus-key
                                         type
                                         bold-left-label-margin?
+                                        additional-disabled?
                                         on-change]}]
   (let [id-prefix   (get-id-prefix haun-asetus-key)
         checkbox-id (str id-prefix "-checkbox")
@@ -141,7 +142,7 @@
       {:input-component [checkbox-fn
                          {:id              checkbox-id
                           :checked?        checked?
-                          :disabled?       disabled?
+                          :disabled?       (or disabled? additional-disabled?)
                           :on-change       (fn []
                                              (re-frame/dispatch [:haun-asetukset/set-haun-asetus
                                                                  haku-oid
@@ -461,7 +462,7 @@
      {:haku-oid                haku-oid
       :haun-asetus-key         :haun-asetukset/synteettiset-hakemukset
       :type                    :slider
-      :disabled?               disabled?
+      :additional-disabled?    disabled?
       :on-change               (fn [checked?]
                                  (re-frame/dispatch [:haun-asetukset/set-haun-asetus
                                                      haku-oid

--- a/src/cljs/hakukohderyhmapalvelu/views/haun_asetukset_panel.cljs
+++ b/src/cljs/hakukohderyhmapalvelu/views/haun_asetukset_panel.cljs
@@ -541,6 +541,12 @@
         :haun-asetus-key         :haun-asetukset/useita-hakemuksia
         :type                    :slider
         :bold-left-label-margin? false}]
+      (when kk?
+        [haun-asetukset-checkbox
+         {:haku-oid                haku-oid
+          :haun-asetus-key         :haun-asetukset/synteettiset-hakemukset
+          :type                    :slider
+          :bold-left-label-margin? false}])
       [hakijakohtainen-paikan-vastaanottoaika
        {:haku-oid haku-oid}]
       [haun-asetukset-date-time


### PR DESCRIPTION
Allow enabling / disabling use of synthetic applications in haku with a new property, and setting a hardcoded (in config) form id to use for synthetic application enabled haku.

NB! Requires new translation(s) and configuration for actual form keys per environment.