### PR TITLE
OPHSUPA-84 Lisätty suorituspalvelun tarvitsemia parametreja

### DIFF
--- a/src/cljs/hakukohderyhmapalvelu/i18n/translations.cljs
+++ b/src/cljs/hakukohderyhmapalvelu/i18n/translations.cljs
@@ -43,6 +43,8 @@
                     :oppilaitosten-virkailijoiden-valintapalvelun-kaytto-estetty {:fi "Oppilaitosten virkailijoiden valintapalvelun käyttö estetty"}
                     :valintaesityksen-hyvaksyminen                               {:fi "Valintaesityksen hyväksyminen"}
                     :koetulosten-tallentaminen                                   {:fi "Koetulosten tallentaminen"}
+                    :suoritusten-vahvistuspaiva                                  {:fi "Suoritusten vahvistuspäivä"}
+                    :valintalaskentapaiva                                        {:fi "Valintalaskentapäivä"}
                     :muutoksia-ei-viela-tallennettu                              {:fi "Muutoksia ei vielä tallennettu"}
                     :tayta-pakolliset                                            {:fi "Täytä kaikki pakolliset kohdat"}
                     :tallenna                                                    {:fi "TALLENNA"}}

--- a/src/cljs/hakukohderyhmapalvelu/ohjausparametrit/haun_asetukset_ohjausparametrit_mapping.cljs
+++ b/src/cljs/hakukohderyhmapalvelu/ohjausparametrit/haun_asetukset_ohjausparametrit_mapping.cljs
@@ -76,7 +76,13 @@
     :PH_VEH
 
     :haun-asetukset/koetulosten-tallentaminen
-    :PH_KTT))
+    :PH_KTT
+
+    :haun-asetukset/suoritusten-vahvistuspaiva
+    :suoritustenVahvistuspaiva
+
+    :haun-asetukset/valintalaskentapaiva
+    :valintalaskentapaiva))
 
 (defn- parse-int [value]
   (let [i (.parseInt js/Number value 10)]
@@ -130,7 +136,9 @@
           :haun-asetukset/automaattinen-hakukelpoisuus-paattyy
           :haun-asetukset/harkinnanvaraisen-valinnan-paatosten-tallennus-paattyy
           :haun-asetukset/valintaesityksen-hyvaksyminen
-          :haun-asetukset/koetulosten-tallentaminen}))
+          :haun-asetukset/koetulosten-tallentaminen
+          :haun-asetukset/suoritusten-vahvistuspaiva
+          :haun-asetukset/valintalaskentapaiva}))
 
 (defn- local->long [date]
   (-> date

--- a/src/cljs/hakukohderyhmapalvelu/subs/haun_asetukset_subs.cljs
+++ b/src/cljs/hakukohderyhmapalvelu/subs/haun_asetukset_subs.cljs
@@ -90,7 +90,7 @@
           "haunkohdejoukko_12#"))))
 
 (re-frame/reg-sub
-  :haun-asetukset/toinen_aste?
+  :haun-asetukset/toinen_aste_yhteishaku?
   (fn [[_ haku-oid]]
     [(re-frame/subscribe [:haun-asetukset/haku haku-oid])])
   (fn [[haku]]

--- a/src/cljs/hakukohderyhmapalvelu/views/haun_asetukset_panel.cljs
+++ b/src/cljs/hakukohderyhmapalvelu/views/haun_asetukset_panel.cljs
@@ -692,7 +692,7 @@
   (let [haku-oid  @(re-frame/subscribe [:haun-asetukset/selected-haku-oid])
         haku      @(re-frame/subscribe [:haun-asetukset/haku haku-oid])
         lang      @(re-frame/subscribe [:lang])
-        toinen-aste? @(re-frame/subscribe [:haun-asetukset/toinen_aste? haku-oid])
+        toinen-aste-yhteishaku? @(re-frame/subscribe [:haun-asetukset/toinen_aste_yhteishaku? haku-oid])
         kk? @(re-frame/subscribe [:haun-asetukset/kk? haku-oid])
         save-status @(re-frame/subscribe [:haun-asetukset/save-status])
         save-errors (take-last 5 (:errors save-status))
@@ -769,28 +769,40 @@
           :haun-asetus-key         :haun-asetukset/automaattinen-hakukelpoisuus-paattyy
           :required?               false
           :bold-left-label-margin? false}])
-      (when toinen-aste?
+      (when toinen-aste-yhteishaku?
         [haun-asetukset-date-time
          {:haku-oid                haku-oid
           :haun-asetus-key         :haun-asetukset/harkinnanvaraisen-valinnan-paatosten-tallennus-paattyy
           :required?               false
           :bold-left-label-margin? false}])
-      (when toinen-aste?
+      (when toinen-aste-yhteishaku?
         [haun-asetus-aikavali-container
          {:haku-oid                haku-oid
           :required?               false
           :haun-asetus-key         :haun-asetukset/oppilaitosten-virkailijoiden-valintapalvelun-kaytto-estetty}])
-      (when toinen-aste?
+      (when toinen-aste-yhteishaku?
         [haun-asetukset-date-time
          {:haku-oid                haku-oid
           :haun-asetus-key         :haun-asetukset/valintaesityksen-hyvaksyminen
           :required?               false
           :bold-left-label-margin? false}])
-      (when toinen-aste?
+      (when toinen-aste-yhteishaku?
         [haun-asetukset-date-time
          {:haku-oid                haku-oid
           :haun-asetus-key         :haun-asetukset/koetulosten-tallentaminen
           :required?               false
+          :bold-left-label-margin? false}])
+      (when toinen-aste-yhteishaku?
+        [haun-asetukset-date-time
+         {:haku-oid                haku-oid
+          :haun-asetus-key         :haun-asetukset/suoritusten-vahvistuspaiva
+          :required?               true
+          :bold-left-label-margin? false}])
+      (when toinen-aste-yhteishaku?
+        [haun-asetukset-date-time
+         {:haku-oid                haku-oid
+          :haun-asetus-key         :haun-asetukset/valintalaskentapaiva
+          :required?               true
           :bold-left-label-margin? false}])
       [tallenna-haun-asetukset-label
        {:id                      "id"


### PR DESCRIPTION
  2. asteen hakuihin lisätty seuraavat pakolliset parametrit:
    - suoritusten vahvistupäivä, päivämäärä jolloin suorituksen tulee olla valmis jotta se otetaan laskennassa huomioon
    - valintalaskentapäivä, päivämäärä jonka jälkeen Koskeen vietyjä suorituksia ei oteta laskennassa huomioon