### PR TITLE
OY-5454 Upgrade undertow

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <url>https://github.com/Opetushallitus/hakukohderyhmapalvelu</url>
     <connection>scm:git:git://github.com/Opetushallitus/hakukohderyhmapalvelu.git</connection>
     <developerConnection>scm:git:ssh://git@github.com/Opetushallitus/hakukohderyhmapalvelu.git</developerConnection>
-    <tag>7262d5940290b94e9932984df99a38cbdc3b1a00</tag>
+    <tag>2eca2829e56dba4277b58b6cc66d2376f5ab0bdd</tag>
   </scm>
   <build>
     <sourceDirectory>src/clj</sourceDirectory>
@@ -133,11 +133,6 @@
         <version>1.6.0</version>
       </dependency>
       <dependency>
-        <groupId>com.amazonaws</groupId>
-        <artifactId>aws-java-sdk-s3</artifactId>
-        <version>1.12.785</version>
-      </dependency>
-      <dependency>
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-server</artifactId>
         <version>9.4.57.v20241219</version>
@@ -155,7 +150,7 @@
       <dependency>
         <groupId>io.undertow</groupId>
         <artifactId>undertow-core</artifactId>
-        <version>2.3.20.Final</version>
+        <version>2.3.21.Final</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -380,6 +375,11 @@
       <groupId>fi.vm.sade.dokumenttipalvelu</groupId>
       <artifactId>dokumenttipalvelu</artifactId>
       <version>6.15-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+      <groupId>opiskelijavalinnat-utils</groupId>
+      <artifactId>clj-ring-db-cas-session</artifactId>
+      <version>1.0.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>day8.re-frame</groupId>

--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,7 @@
                          [org.eclipse.jetty/jetty-server "9.4.57.v20241219"]
                          [org.yaml/snakeyaml "2.0"]
                          [com.google.protobuf/protobuf-java "3.25.5"]
-                         [io.undertow/undertow-core "2.3.20.Final"]]
+                         [io.undertow/undertow-core "2.3.21.Final"]]
   :dependencies [[org.clojure/clojure "1.11.2"]
                  [org.clojure/clojurescript "1.11.132"]
                  [com.google.javascript/closure-compiler-unshaded "v20240317"]


### PR DESCRIPTION
Undertow'n uusimmassa versiossa on korjattu tietoturvahaavoittuvuus CVE-2025-12543, mutta jostain syystä sitä ei ole päivitetty vielä haavoittuvuustietokantoihin. Toivottavasti päivittyvät jossain kohtaa.

https://github.com/undertow-io/undertow/releases/tag/2.3.21.Final